### PR TITLE
swift-format feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
         features:
           - jemalloc
           - SwiftFormat
+          - swift-format
         baseImage:
           - swift:5.7
     steps:
@@ -34,6 +35,7 @@ jobs:
         features:
           - jemalloc
           - SwiftFormat
+          - swift-format
         baseImage:
           - swift:5.7
     steps:

--- a/src/swift-format/devcontainer-feature.json
+++ b/src/swift-format/devcontainer-feature.json
@@ -1,0 +1,20 @@
+{
+    "name": "swift-format",
+    "id": "swift-format",
+    "version": "0.1.0",
+    "description": "A feature that installs Apple's swift-format",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "default"
+            ],
+            "default": "default",
+            "description": "Version of swift-format"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/git"
+    ]
+}

--- a/src/swift-format/install.sh
+++ b/src/swift-format/install.sh
@@ -40,7 +40,7 @@ getSwiftFormatVersion()
         "5.5") VERSION_FILTER="0.50500.*";;
         "5.6") VERSION_FILTER="0.50600.*";;
         "5.7") VERSION_FILTER="0.50700.*";;
-        *) VERSION_FILTER="main";;
+        *) echo "main"; return;;
     esac
     # get version from git tags
     VERSION=$(git tag -l "$VERSION_FILTER" | tail -n 1)

--- a/src/swift-format/install.sh
+++ b/src/swift-format/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+# The 'install.sh' entrypoint script is always executed as the root user.
+#
+# These following environment variables are passed in by the dev container CLI.
+# These may be useful in instances where the context of the final 
+# remoteUser or containerUser is useful.
+# For more details, see https://containers.dev/implementors/features#user-env-var
+# echo "The effective dev container remoteUser is '$_REMOTE_USER'"
+# echo "The effective dev container remoteUser's home directory is '$_REMOTE_USER_HOME'"
+
+# echo "The effective dev container containerUser is '$_CONTAINER_USER'"
+# echo "The effective dev container containerUser's home directory is '$_CONTAINER_USER_HOME'"
+
+STARTDIR=$(pwd)
+TEMPDIR=$(mktemp -d)
+VERSION=${VERSION:-"default"}
+
+cleanup()
+{
+    cd "$STARTDIR"
+    if [ -n "$TEMPDIR" ]; then
+        rm -rf "$TEMPDIR"
+    fi
+}
+
+# Work out swift-format version tag from swift version
+getSwiftFormatVersion()
+{
+    VERSION_FILTER="main"
+    # get swift version
+    SWIFT_VERSION=$(swift --version | egrep -o 'Swift version [0-9]+.[0-9]+' | tail -c +15)
+    # convert to swift-format version filter
+    case $SWIFT_VERSION in
+        "5.2") VERSION_FILTER="0.50200.*";;
+        "5.3") VERSION_FILTER="0.50300.*";;
+        "5.4") VERSION_FILTER="0.50400.*";;
+        "5.5") VERSION_FILTER="0.50500.*";;
+        "5.6") VERSION_FILTER="0.50600.*";;
+        "5.7") VERSION_FILTER="0.50700.*";;
+        *) VERSION_FILTER="main";;
+    esac
+    # get version from git tags
+    VERSION=$(git tag -l "$VERSION_FILTER" | tail -n 1)
+    echo $VERSION
+}
+
+trap cleanup EXIT $?
+
+echo "Downloading apple/swift-format"
+git clone https://github.com/apple/swift-format "$TEMPDIR"
+cd "$TEMPDIR"
+
+if [ "$VERSION" == "default" ]; then
+  VERSION=$(getSwiftFormatVersion)
+fi
+
+git checkout "$VERSION"
+swift build -c release --product swift-format
+SWIFT_FORMAT=$(swift build -c release --show-bin-path)/swift-format
+cp "$SWIFT_FORMAT" /usr/local/bin

--- a/test/SwiftFormat/test.sh
+++ b/test/SwiftFormat/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This test file will be executed against an auto-generated devcontainer.json that
-# includes the 'jemalloc' Feature with no options.
+# includes the 'SwiftFormat' Feature with no options.
 #
 # For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
 #
@@ -9,7 +9,7 @@
 # {
 #    "image": "<..some-base-image...>",
 #    "features": {
-#      "jemalloc": {}
+#      "SwiftFormat": {}
 #    },
 #    "remoteUser": "root"
 # }

--- a/test/swift-format/scenarios.json
+++ b/test/swift-format/scenarios.json
@@ -1,0 +1,17 @@
+{
+    "swift-format-default-version": {
+        "image": "swift:5.7",
+        "features": {
+            "swift-format": {
+            }
+        }
+    },
+    "swift-format-explicit-version": {
+        "image": "swift:5.7",
+        "features": {
+            "swift-format": {
+                "version": "0.50700.0"
+            }
+        }
+    }
+}

--- a/test/swift-format/swift-format-default-version.sh
+++ b/test/swift-format/swift-format-default-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This test file will be executed against one of the scenarios devcontainer.json test that
+# includes the 'SwiftFormat' feature.
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "Check SwiftFormat version" bash -c "swift-format --version | grep 0.50700."
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/swift-format/swift-format-explicit-version.sh
+++ b/test/swift-format/swift-format-explicit-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This test file will be executed against one of the scenarios devcontainer.json test that
+# includes the 'SwiftFormat' feature.
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "Check SwiftFormat version" bash -c "swift-format --version | grep 0.50700.0"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/swift-format/test.sh
+++ b/test/swift-format/test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the 'jemalloc' Feature with no options.
+#
+# For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
+#
+# Eg:
+# {
+#    "image": "<..some-base-image...>",
+#    "features": {
+#      "jemalloc": {}
+#    },
+#    "remoteUser": "root"
+# }
+#
+# Thus, the value of all options will fall back to the default value in
+# the Feature's 'devcontainer-feature.json'.
+#
+# These scripts are run as 'root' by default. Although that can be changed
+# with the '--remote-user' flag.
+#
+# This test can be run with the following command:
+#
+#    devcontainer features test \
+#                   --features SwiftFormat \
+#                   --remote-user root  \
+#                   --skip-scenarios    \
+#                   --base-image swift:5.7 \
+#                   /path/to/this/repo
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "Check Installed" bash -c "swift-format --version"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/swift-format/test.sh
+++ b/test/swift-format/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This test file will be executed against an auto-generated devcontainer.json that
-# includes the 'jemalloc' Feature with no options.
+# includes the 'swift-format' Feature with no options.
 #
 # For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
 #
@@ -9,7 +9,7 @@
 # {
 #    "image": "<..some-base-image...>",
 #    "features": {
-#      "jemalloc": {}
+#      "swift-format": {}
 #    },
 #    "remoteUser": "root"
 # }
@@ -23,7 +23,7 @@
 # This test can be run with the following command:
 #
 #    devcontainer features test \
-#                   --features SwiftFormat \
+#                   --features swift-format \
 #                   --remote-user root  \
 #                   --skip-scenarios    \
 #                   --base-image swift:5.7 \


### PR DESCRIPTION
Given I added a Nick Lockwood's swiftformat feature it is only fair we add an apple version as well
This one is slightly different as the swift-format version is more linked to the swift version. So I have added a function to work out which swift-format version to download based off the swift version. Although you can still override it with the version option.

This brings up the question, given we have both swift formats which both have very similar names should we rename them to `nicklockwood-swiftformat` and `apple-swift-format`